### PR TITLE
Toggle hamburger menulist on/off

### DIFF
--- a/src/components/ListItemLink.js
+++ b/src/components/ListItemLink.js
@@ -1,21 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import { Link } from 'react-router-dom';
-
-const styles = theme => ({
-    root: {
-        display: 'flex',
-        flexDirection: 'column',
-        width: 360,
-    },
-    lists: {
-        backgroundColor: theme.palette.background.paper,
-    },
-});
 
 class ListItemLink extends React.Component {
     renderLink = itemProps => <Link to={this.props.to} {...itemProps} />;
@@ -55,4 +43,4 @@ ListItemLink.propTypes = {
 //     to: PropTypes.string.isRequired,
 // };
 
-export default withStyles(styles)(ListItemLink);
+export default ListItemLink;

--- a/src/components/MiniDrawer.js
+++ b/src/components/MiniDrawer.js
@@ -1,62 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles, Hidden } from '@material-ui/core';
+import { withStyles } from '@material-ui/core';
 import Drawer from '@material-ui/core/Drawer';
-import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
-import List from '@material-ui/core/List';
 import Typography from '@material-ui/core/Typography';
 import Divider from '@material-ui/core/Divider';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
-import InboxIcon from '@material-ui/icons/MoveToInbox';
-import MailIcon from '@material-ui/icons/Mail';
 import MenuIcon from '@material-ui/icons/Menu';
 import IconButton from '@material-ui/core/IconButton';
 import SimpleList from './SimpleList';
 import { Link } from 'react-router-dom';
 
-const drawerWidth = 240;
-
-const styles = theme => ({
-    root: {
-        display: 'flex',
-    },
-    appBar: {
-        marginRight: drawerWidth,
-        width: '100%',
-        [theme.breakpoints.down('lg')]: {
-            width: `calc(100% - ${drawerWidth}px)`,
-        },
-    },
-    drawer: {
-        width: drawerWidth,
-        flexShrink: 0,
-    },
-    drawerPaper: {
-        width: drawerWidth,
-    },
-    toolbar: theme.mixins.toolbar,
-    content: {
-        flexGrow: 1,
-        backgroundColor: theme.palette.background.default,
-        padding: theme.spacing.unit * 3,
+const styles = {
+    menuList: {
+        minWidth: '15%',
+        height: '25%',
     },
     header: {
-        marginLeft: '200px',
+        display: 'flex',
+        justifyContent: 'space-between',
     },
     droomLink: {
         color: 'white',
         textDecoration: 'none',
     },
-
-    menuButton: {
-        display: 'flex',
-        alignSelf: 'flex-end',
-    },
-});
+};
 
 class PermanentDrawerRight extends React.Component {
     state = {
@@ -71,62 +39,34 @@ class PermanentDrawerRight extends React.Component {
         const { classes } = this.props;
 
         return (
-            <div className={classes.root}>
-                <CssBaseline />
-
-                <AppBar position="fixed" className={classes.appBar}>
-                    <Toolbar>
-                        <Typography
-                            className={classes.header}
-                            variant="h4"
+            <div>
+                <AppBar position="fixed">
+                    <Toolbar className={classes.header}>
+                        <IconButton
                             color="inherit"
-                            noWrap
+                            onClick={this.handleDrawerToggle}
                         >
+                            <MenuIcon />
+                        </IconButton>
+                        <Typography variant="h4" color="inherit" noWrap>
                             <Link to={'/main'} className={classes.droomLink}>
                                 DROOM
                             </Link>
                         </Typography>
-                        <Hidden mdUp>
-                            <IconButton
-                                color="inherit"
-                                aria-label="Open drawer"
-                                onClick={this.handleDrawerToggle}
-                                className={classes.menuButton}
-                            >
-                                <MenuIcon />
-                            </IconButton>
-                        </Hidden>
                     </Toolbar>
                 </AppBar>
-
-                <Hidden mdUp>
-                    <Drawer
-                        variant="temporary"
-                        anchor={'right'}
-                        open={this.state.mobileOpen}
-                        onClose={this.handleDrawerToggle}
-                        classes={{
-                            paper: classes.drawerPaper,
-                        }}
-                    >
-                        <Divider />
-                        <SimpleList />
-                    </Drawer>
-                </Hidden>
-                <Hidden smDown>
-                    <Drawer
-                        className={classes.drawer}
-                        variant="permanent"
-                        classes={{
-                            paper: classes.drawerPaper,
-                        }}
-                        anchor="right"
-                    >
-                        <div className={classes.toolbar} />
-                        <Divider />
-                        <SimpleList />
-                    </Drawer>
-                </Hidden>
+                <Drawer
+                    variant="temporary"
+                    anchor="right"
+                    open={this.state.mobileOpen}
+                    onClose={this.handleDrawerToggle}
+                    classes={{
+                        paper: classes.menuList,
+                    }}
+                >
+                    <Divider />
+                    <SimpleList />
+                </Drawer>
             </div>
         );
     }

--- a/src/components/SimpleList.js
+++ b/src/components/SimpleList.js
@@ -1,18 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItemLink from './ListItemLink';
 import { connect } from 'react-redux';
 import AccountBox from '@material-ui/icons/AccountBox';
-
-const styles = theme => ({
-    root: {
-        width: '100%',
-        maxWidth: 360,
-        backgroundColor: theme.palette.background.paper,
-    },
-});
 
 function SimpleList(props) {
     const { classes } = props;
@@ -21,30 +12,24 @@ function SimpleList(props) {
         url = `/profile/company/${props.account.id}`;
     }
     return (
-        <div className={classes.root}>
-            <List component="nav">
-                <ListItemLink
-                    to={url}
-                    primary={'Profile'}
-                    icon={<AccountBox />}
-                />
-                <ListItemLink
-                    to={`/matches`}
-                    primary={'Matches'}
-                    icon={<AccountBox />}
-                />
-                <ListItemLink
-                    to={`/messages`}
-                    primary="Messages"
-                    icon={<AccountBox />}
-                />
-                <ListItemLink
-                    to={`/signOut`}
-                    primary="Sign Out"
-                    icon={<AccountBox />}
-                />
-            </List>
-        </div>
+        <List component="nav">
+            <ListItemLink to={url} primary={'Profile'} icon={<AccountBox />} />
+            <ListItemLink
+                to={`/matches`}
+                primary={'Matches'}
+                icon={<AccountBox />}
+            />
+            <ListItemLink
+                to={`/messages`}
+                primary="Messages"
+                icon={<AccountBox />}
+            />
+            <ListItemLink
+                to={`/signOut`}
+                primary="Sign Out"
+                icon={<AccountBox />}
+            />
+        </List>
     );
 }
 
@@ -59,4 +44,4 @@ const mapStateToProps = state => ({
 export default connect(
     mapStateToProps,
     {}
-)(withStyles(styles)(SimpleList));
+)(SimpleList);


### PR DESCRIPTION
Before:
<img width="691" alt="Screen Shot 2019-03-14 at 3 30 29 PM" src="https://user-images.githubusercontent.com/4283962/54398333-d8450d00-4676-11e9-8591-443dee1d4666.png">

After:
<img width="1680" alt="Screen Shot 2019-03-14 at 4 30 17 PM" src="https://user-images.githubusercontent.com/4283962/54398336-dd09c100-4676-11e9-8dd2-c1ad25cc3c7d.png">

Stylist updates:
- The menu list was always present, even when the user didn't click on the menu icon
- The menu icon was only present at a certain window size
- The menu list was present on top of the menu icon, making it inaccessible for toggle off
- The menu list was too long
I changed the `Drawer` settings to fix all of the above.